### PR TITLE
doc: Specify SettingsCabinet::Base in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or install it yourself as:
 DSL is very similar to settingslogic.
 
 ```ruby
-class Settings < SettingsCabinet
+class Settings < SettingsCabinet::Base
   using SettingsCabinet::DSL
 
   source Rails.root.join("config", "settings.yml")
@@ -75,7 +75,7 @@ Settings.load!
 ```
 or
 ```ruby
-class Settings < SettingsCabinet
+class Settings < SettingsCabinet::Base
   using SettingsCabinet::DSL
   using SettingsCabinet::Control
 


### PR DESCRIPTION
Hello.

The DSL in the README says `class Settings < SettingsCabinet`,
but `SettingsCabinet` is just a module and is supposed to inherit from the `SettingsCabinet::Base` class.