### PR TITLE
feat: add keys method support for Hash structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Accessors are defined in the same way as settingslogic, but writers do not.
 ```ruby
 Settings.foo.bar #=> "nested setting"
 Settings[:baz]   #=> 9
+
+# Hash Keys Support - Get all available keys from Hash structures
+Settings.foo.keys  #=> [:bar]
+Settings.keys      #=> [:foo, :baz, :quz]
 ```
 
 You can explicitly load all your settings, if needed.

--- a/lib/settings_cabinet/settings.rb
+++ b/lib/settings_cabinet/settings.rb
@@ -25,7 +25,7 @@ module SettingsCabinet
     using AccessorBuilder
 
     def initialize(hash)
-      @values = hash.transform_values { |v| transform_value(v) }
+      @values = hash.transform_values { |v| v.is_a?(::Hash) ? self.class.new(v) : v }
 
       define_accessors!(@values)
     end
@@ -52,31 +52,11 @@ module SettingsCabinet
     end
 
     def to_h
-      @values.transform_values { |v| transform_to_hash_value(v) }
+      @values.transform_values { |v| v.is_a?(self.class) ? v.to_h : v }
     end
 
     def keys
       @values.keys
-    end
-
-    private
-
-    def transform_value(value)
-      case value
-      when ::Hash
-        self.class.new(value)
-      else
-        value
-      end
-    end
-
-    def transform_to_hash_value(value)
-      case value
-      when self.class
-        value.to_h
-      else
-        value
-      end
     end
   end
 end

--- a/lib/settings_cabinet/settings.rb
+++ b/lib/settings_cabinet/settings.rb
@@ -25,7 +25,7 @@ module SettingsCabinet
     using AccessorBuilder
 
     def initialize(hash)
-      @values = hash.transform_values { |v| v.is_a?(::Hash) ? self.class.new(v) : v }
+      @values = hash.transform_values { |v| transform_value(v) }
 
       define_accessors!(@values)
     end
@@ -52,7 +52,31 @@ module SettingsCabinet
     end
 
     def to_h
-      @values.transform_values { |v| v.is_a?(self.class) ? v.to_h : v }
+      @values.transform_values { |v| transform_to_hash_value(v) }
+    end
+
+    def keys
+      @values.keys
+    end
+
+    private
+
+    def transform_value(value)
+      case value
+      when ::Hash
+        self.class.new(value)
+      else
+        value
+      end
+    end
+
+    def transform_to_hash_value(value)
+      case value
+      when self.class
+        value.to_h
+      else
+        value
+      end
     end
   end
 end

--- a/spec/fixtures/settings.yml
+++ b/spec/fixtures/settings.yml
@@ -5,6 +5,13 @@ defaults: &defaults
   setting4:
     setting_child1: "child1"
     setting_child2: [1, 2, 3]
+  settings5:
+    target1:
+      key1: "value1"
+      key2: "value2"
+    target2:
+      key1: "value1"
+      key2: "value2"
 
 development:
   <<: *defaults

--- a/spec/settings_cabinet_spec.rb
+++ b/spec/settings_cabinet_spec.rb
@@ -142,8 +142,29 @@ RSpec.describe SettingsCabinet do
     it "returns a hash" do
       expect(DevelopmentSettings.to_h).to eq(
         { setting1: 1, setting2: "override 2", setting3: 9,
-          setting4: { setting_child1: "child1", setting_child2: [1, 2, 3] } }
+          setting4: { setting_child1: "child1", setting_child2: [1, 2, 3] },
+          settings5: { 
+            target1: { key1: "value1", key2: "value2" },
+            target2: { key1: "value1", key2: "value2" }
+          } }
       )
+    end
+  end
+
+  context "hash keys functionality" do
+    it "allows access to hash keys method" do
+      hash_test = Settings.defaults.settings5
+      expect(hash_test.keys).to eq([:target1, :target2])
+    end
+
+    it "allows access to nested hash keys" do
+      target1 = Settings.defaults.settings5.target1
+      expect(target1.keys).to eq([:key1, :key2])
+    end
+
+    it "allows access to root level keys" do
+      defaults_keys = Settings.defaults.keys
+      expect(defaults_keys).to include(:setting1, :setting2, :setting3, :setting4, :settings5)
     end
   end
 

--- a/spec/settings_cabinet_spec.rb
+++ b/spec/settings_cabinet_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe SettingsCabinet do
       expect(DevelopmentSettings.to_h).to eq(
         { setting1: 1, setting2: "override 2", setting3: 9,
           setting4: { setting_child1: "child1", setting_child2: [1, 2, 3] },
-          settings5: { 
+          settings5: {
             target1: { key1: "value1", key2: "value2" },
             target2: { key1: "value1", key2: "value2" }
           } }
@@ -151,15 +151,15 @@ RSpec.describe SettingsCabinet do
     end
   end
 
-  context "hash keys functionality" do
+  context "with hash keys functionality" do
     it "allows access to hash keys method" do
       hash_test = Settings.defaults.settings5
-      expect(hash_test.keys).to eq([:target1, :target2])
+      expect(hash_test.keys).to eq(%i[target1 target2])
     end
 
     it "allows access to nested hash keys" do
       target1 = Settings.defaults.settings5.target1
-      expect(target1.keys).to eq([:key1, :key2])
+      expect(target1.keys).to eq(%i[key1 key2])
     end
 
     it "allows access to root level keys" do


### PR DESCRIPTION
## Summary

* For developers migrating from SettingsLogic, this removes one more friction point since SettingsLogic users are already used to calling `.keys` on their settings objects.
* Adds `.keys` method to Settings class for easier configuration inspection and debugging.

## Usage Examples

Instead of having to guess what configuration keys are available:

```yaml
# YAML config
database:
  host: localhost
  port: 5432
  username: postgres
redis:
  url: redis://localhost:6379
  timeout: 5
```

```ruby
# Now you can easily inspect what's available
Settings.keys                    # => [:database, :redis]
Settings.database.keys           # => [:host, :port, :username]
Settings.redis.keys              # => [:url, :timeout]
```

